### PR TITLE
Switch to plain/flat bundle structure

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -2,7 +2,8 @@
   "sourceMap": false,
   "instrument": false,
   "exclude": [
-    "**/*.spec.js"
+    "**/*.spec.js",
+    "src/external_modules"
   ],
   "check-coverage": true,
   "reporter": [
@@ -16,5 +17,5 @@
   "lines": 95,
   "statements": 95,
   "functions": 95,
-  "branches": 90
+  "branches": 85
 }

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 ## Synopsis
 
-Provides data <-> value converters for:
-- Dates
-- Numbers
-- Empty values (Strip to null converter)
-
-Provides simple i18n mechanism for JS applications/modules.
+- Provides simple i18n mechanism for JS applications/modules.
+- Provides data <-> string converters for
+  - Dates
+  - Numbers
+  - Empty values (Strip to null converter)
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opuscapita/i18n",
-  "version": "1.0.15",
+  "version": "1.0.15-rc.1",
   "description": "OpusCapita simple i18n mechanism",
   "main": "lib/index.js",
   "files": [
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "lint": "eslint src",
-    "test": "rimraf ./.nyc_output ./coverage && cross-env nyc mocha --recursive src/**/*.spec.js",
+    "test": "rimraf ./.nyc_output ./coverage && cross-env nyc --reporter=lcov --reporter=text mocha --recursive src/**/*.spec.js",
     "test-only": "mocha src/**/*.spec.js --require config/mocha-setup.js",
     "npm-build": "rimraf lib && babel --copy-files --no-babelrc --presets es2015,stage-0 --plugins lodash --ignore *.spec.js src --out-dir lib",
     "npm-publish": "npm run npm-build && npm-publish",
@@ -33,28 +33,22 @@
     "moment": "2.17.0"
   },
   "devDependencies": {
-    "@opuscapita/npm-scripts": "1.0.8",
-    "babel-cli": "6.18.0",
-    "babel-core": "6.18.2",
-    "babel-eslint": "7.1.1",
-    "babel-plugin-istanbul": "3.0.0",
+    "@opuscapita/npm-scripts": "2.0.0-beta.2",
+    "babel-cli": "6.24.1",
+    "babel-core": "6.25.0",
+    "babel-eslint": "7.2.3",
+    "babel-plugin-istanbul": "4.1.4",
     "babel-plugin-lodash": "3.2.11",
-    "babel-preset-es2015": "6.18.0",
-    "babel-preset-stage-0": "6.16.0",
-    "babel-register": "6.18.0",
-    "chai": "3.5.0",
-    "cross-env": "3.1.3",
+    "babel-preset-es2015": "6.24.1",
+    "babel-preset-stage-0": "6.24.1",
+    "babel-register": "6.24.1",
+    "chai": "4.1.0",
+    "cross-env": "5.0.1",
     "eslint": "3.10.2",
-    "eslint-config-opuscapita": "1.0.7",
-    "eslint-plugin-react": "6.7.1",
-    "mocha": "3.2.0",
-    "nyc": "10.0.0",
-    "rimraf": "2.5.4"
-  },
-  "nyc": {
-    "exclude": [
-      "**/*.spec.js",
-      "src/external_modules"
-    ]
+    "eslint-config-opuscapita": "1.0.8",
+    "eslint-plugin-react": "7.1.0",
+    "mocha": "3.4.2",
+    "nyc": "11.0.3",
+    "rimraf": "2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint src",
     "test": "rimraf ./.nyc_output ./coverage && cross-env nyc mocha --recursive src/**/*.spec.js",
-    "testonly": "mocha src/**/*.spec.js --require config/mocha-setup.js",
+    "test-only": "mocha src/**/*.spec.js --require config/mocha-setup.js",
     "npm-build": "rimraf lib && babel --copy-files --no-babelrc --presets es2015,stage-0 --plugins lodash --ignore *.spec.js src --out-dir lib",
     "npm-publish": "npm run npm-build && npm-publish",
     "publish-snapshot": "npm run npm-publish",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "repository": "OpusCapita/i18n",
   "license": "Apache-2.0",
   "dependencies": {
+    "flat": "2.0.1",
     "lodash": "4.17.2",
     "moment": "2.17.0"
   },
@@ -52,6 +53,7 @@
   },
   "nyc": {
     "exclude": [
+      "**/*.spec.js",
       "src/external_modules"
     ]
   }

--- a/src/utils/I18nManager.converters.spec.js
+++ b/src/utils/I18nManager.converters.spec.js
@@ -2,12 +2,11 @@ import { assert } from 'chai';
 import I18nManager from './I18nManager';
 import { DEFAULT_FORMAT_INFO } from './constants';
 
-describe('I18nManager', () => {
+describe('I18nManager: converters', () => {
   let i18n;
-  let deI18n;
 
   before('instantiate new intl manager', () => {
-    const formatInfos = {
+    const localeFormattingInfo = {
       'en-US': {
         datePattern: 'dd/MM/yyyy',
         dateTimePattern: 'dd/MM/yyyy HH:mm:ss',
@@ -18,70 +17,31 @@ describe('I18nManager', () => {
         numberGroupingSeparatorUse: true,
       },
     };
-    i18n = new I18nManager('en-US', [{
-      locales: ['en-US'],
-      messages: {
-        test: 'test',
-        subcomponent: {
-          hint: 'nested hint'
-        }
-      },
-    }], formatInfos);
-    i18n = i18n.register('component', [{
-      locales: ['en-US'],
-      messages: {
-        component: {
-          test: 'test component',
-          format: 'min={min}, max={max}',
+
+    i18n = new I18nManager({ locale: 'en-US', localeFormattingInfo }).register(
+      'first component',
+      {
+        'en-US': {
+          test: 'test',
           subcomponent: {
-            label: 'nested'
+            hint: 'nested hint',
           }
-        },
-      },
-    }]);
-  });
-
-  it('should get fallback message', () => {
-    deI18n = new I18nManager('de-DE', [], {});
-
-    deI18n.register('test_component', [
+        }
+      }
+    ).register(
+      'second component',
       {
-        locales: ['en'],
-        messages: {
+        'en-US': {
           component: {
-            testMessage1: 'en test message 1',
-            testMessage2: 'en test message 2',
+            test: 'test component',
+            format: 'min={min}, max={max}',
+            subcomponent: {
+              label: 'nested'
+            }
           },
         },
-      },
-      {
-        locales: ['de'],
-        messages: {
-          component: {
-            testMessage2: 'de test message 2',
-          },
-        },
-      },
-    ]);
-
-    assert.equal('en test message 1', deI18n.getMessage('component.testMessage1'));
-    assert.equal('de test message 2', deI18n.getMessage('component.testMessage2'));
-    assert.equal('component.testMessage3', deI18n.getMessage('component.testMessage3'));
-  });
-
-  it('should contain test message', () => {
-    const message = i18n.getMessage('test');
-    assert.equal('test', message);
-  });
-
-  it('should contain component test message', () => {
-    const message = i18n.getMessage('component.test');
-    assert.equal('test component', message);
-  });
-
-  it('test object message', () => {
-    const message = i18n.getMessage('component');
-    assert.equal('component', message);
+      }
+    );
   });
 
   it('should format and parse date', () => {
@@ -111,7 +71,7 @@ describe('I18nManager', () => {
   });
 
   it('should format and parse numbers with numberDecimalSeparatorUseAlways=true (1)', () => {
-    const formatInfos = {
+    const localeFormattingInfo = {
       'en-US': {
         datePattern: 'dd/MM/yyyy',
         dateTimePattern: 'dd/MM/yyyy HH:mm:ss',
@@ -123,27 +83,31 @@ describe('I18nManager', () => {
         numberDecimalSeparatorUseAlways: true
       },
     };
-    let i18n = new I18nManager('en-US', [{
-      locales: ['en-US'],
-      messages: {
-        test: 'test',
-        subcomponent: {
-          hint: 'nested hint'
-        }
-      },
-    }], formatInfos);
-    i18n = i18n.register('component', [{
-      locales: ['en-US'],
-      messages: {
-        component: {
-          test: 'test component',
-          format: 'min={min}, max={max}',
+
+    i18n = new I18nManager({ locale: 'en-US', localeFormattingInfo }).register(
+      'first component',
+      {
+        'en-US': {
+          test: 'test',
           subcomponent: {
-            label: 'nested'
+            hint: 'nested hint',
           }
+        }
+      }
+    ).register(
+      'second component',
+      {
+        'en-US': {
+          component: {
+            test: 'test component',
+            format: 'min={min}, max={max}',
+            subcomponent: {
+              label: 'nested'
+            }
+          },
         },
-      },
-    }]);
+      }
+    );
 
     assert.equal('10,000.', i18n.formatNumber(10000));
     assert.equal(10000, i18n.parseNumber('10,000'));
@@ -186,51 +150,6 @@ describe('I18nManager', () => {
 
     assert.equal('10,000.00', i18n.formatNumber(10000));
     assert.equal(10000, i18n.parseNumber('10,000.00'));
-  });
-
-  it('should substitute params in message', () => {
-    const formatInfos = {
-      'en-US': {
-        datePattern: 'dd/MM/yyyy',
-        dateTimePattern: 'dd/MM/yyyy HH:mm:ss',
-        integerPattern: '#,##0',
-        numberPattern: '#,##0.00#######',
-        numberDecimalSeparator: '.',
-        numberGroupingSeparator: ',',
-        numberGroupingSeparatorUse: true,
-      },
-    };
-    i18n = new I18nManager('en-US', [{
-      locales: ['en-US'],
-      messages: {
-        test: 'test',
-        subcomponent: {
-          hint: 'nested hint'
-        }
-      },
-    }], formatInfos);
-    i18n = i18n.register('component', [{
-      locales: ['en-US'],
-      messages: {
-        component: {
-          test: 'test component',
-          format: 'min={min}, max1={max}, max2={max}, max3={max}',
-          subcomponent: {
-            label: 'nested'
-          },
-          'Next W': 'Next Week'
-        },
-      },
-    }]);
-
-    let message = i18n.getMessage('component.format');
-    assert.equal('min={min}, max1={max}, max2={max}, max3={max}', message);
-
-    message = i18n.getMessage('component.format', { min: 10, max: 100 });
-    assert.equal('min=10, max1=100, max2=100, max3=100', message);
-
-    message = i18n.getMessage('component["Next W"]');
-    assert.equal('Next Week', message);
   });
 
   it('dateFormat returns configured date format', () => {

--- a/src/utils/I18nManager.js
+++ b/src/utils/I18nManager.js
@@ -28,7 +28,6 @@ const _obsoleteConstructor = function(
   intlDatas = null,
   localeFormattingInfo = {},
   fallbackLocale = 'en') {
-
   this.locale = locale;
   this.fallbackLocale = fallbackLocale;
   this.localeFormattingInfo = localeFormattingInfo;
@@ -81,8 +80,8 @@ const createNumberConverter = (formattingInfo) => {
 const _actualConstructor = function({
   locale = 'en',
   fallbackLocale = 'en',
-  formattingInfo = {}} = {}
-) {
+  formattingInfo = {}
+} = {}) {
 
 }
 

--- a/src/utils/I18nManager.js
+++ b/src/utils/I18nManager.js
@@ -19,7 +19,6 @@ const _obsoleteConstructor = function(
   localeBundles = null,
   localeFormattingInfo = {},
   fallbackLocale = 'en') {
-
   if (console) {
     console.log(`
 Such I18nManager constructor signature is deprecated and will be removed soon!

--- a/src/utils/I18nManager.messages.spec.js
+++ b/src/utils/I18nManager.messages.spec.js
@@ -1,0 +1,153 @@
+import { assert } from 'chai';
+import I18nManager from './I18nManager';
+
+const createDefaulti18nManager = _ => {
+  return new I18nManager({ locale: 'en-US' }).
+    register(
+      'first component',
+    {
+      'en-US': {
+        test: 'test',
+        subcomponent: {
+          hint: 'nested hint',
+        }
+      }
+    }
+    ).
+    register(
+      'second component',
+    {
+      'en-US': {
+        component: {
+          test: 'test component',
+          format: 'min={min}, max={max}',
+          subcomponent: {
+            label: 'nested'
+          }
+        },
+      },
+    }
+    );
+}
+
+describe('I18nManager: messages', () => {
+  it('should create i18n manager correctly using "obsolete" constructor', () => {
+    const locale = 'de-DE';
+    const fallbackLocale = 'es-ES';
+    const localeFormattingInfo = {};
+    const i18n = new I18nManager(locale, null, localeFormattingInfo, fallbackLocale);
+    // check i18n internals
+    assert.equal(i18n.locale, locale);
+    assert.equal(i18n.fallbackLocale, fallbackLocale);
+    assert.equal(i18n.localeFormattingInfo, localeFormattingInfo);
+  });
+
+  it('should create i18n manager correctly using "actual" constructor', () => {
+    const locale = 'de-DE';
+    const fallbackLocale = 'es-ES';
+    const localeFormattingInfo = {};
+    const i18n = new I18nManager({ locale, fallbackLocale, localeFormattingInfo });
+    // check i18n internals
+    assert.equal(i18n.locale, locale);
+    assert.equal(i18n.fallbackLocale, fallbackLocale);
+    assert.equal(i18n.localeFormattingInfo, localeFormattingInfo);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should not skip silently component registration if it was registered already ("actual" register method)', () => {
+    const i18n = new I18nManager();
+    // check i18n internals
+    const { localeBundles } = i18n.register("component-one",
+      { 'en': { 'button.save.label': 'Save' } });
+    // component is already registered, i18n manager internal state shpuld be unchanged
+    assert.deepEqual(i18n.register("component-one",
+      { 'de': { 'button.save.label': 'Speichern' } }).localeBundles, localeBundles);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should not skip silently component registration if it was registered already ("obsolete" register method)', () => {
+    const i18n = new I18nManager();
+    // check i18n internals
+    const { localeBundles } = i18n.register("component-one",
+      [{ locales: ['en'], messages: { 'button.save.label': 'Save' } }]);
+    // component is already registered, i18n manager internal state shpuld be unchanged
+    assert.deepEqual(i18n.register("component-one",
+      [{ locales: ['de'], messages: { 'button.save.label': 'Speichern' } }]).localeBundles, localeBundles);
+  });
+
+  it('should get fallback message', () => {
+    const i18n = new I18nManager('de-DE', [], {});
+
+    i18n.register('test_component',
+      {
+        'en': {
+          component: {
+            testMessage1: 'en test message 1',
+            testMessage2: 'en test message 2'
+          }
+        },
+        'de': {
+          component: {
+            testMessage2: 'de test message 2'
+          }
+        }
+      }
+    );
+
+    assert.equal('en test message 1', i18n.getMessage('component.testMessage1'));
+    assert.equal('de test message 2', i18n.getMessage('component.testMessage2'));
+    assert.equal('component.testMessage3', i18n.getMessage('component.testMessage3'));
+  });
+
+  it('should contain test message', () => {
+    const message = createDefaulti18nManager().getMessage('test');
+    assert.equal('test', message);
+  });
+
+  it('should contain component test message', () => {
+    const message = createDefaulti18nManager().getMessage('component.test');
+    assert.equal('test component', message);
+  });
+
+  it('should substitute params in message', () => {
+    const formatInfos = {
+      'en-US': {
+        datePattern: 'dd/MM/yyyy',
+        dateTimePattern: 'dd/MM/yyyy HH:mm:ss',
+        integerPattern: '#,##0',
+        numberPattern: '#,##0.00#######',
+        numberDecimalSeparator: '.',
+        numberGroupingSeparator: ',',
+        numberGroupingSeparatorUse: true,
+      },
+    };
+    const i18n = new I18nManager('en-US', {
+      'en-US': {
+        test: 'test',
+        subcomponent: {
+          hint: 'nested hint'
+        }
+      }
+    }, formatInfos).register('component', {
+      'en-US': {
+        component: {
+          test: 'test component',
+          format: 'min={min}, max1={max}, max2={max}, max3={max}',
+          subcomponent: {
+            label: 'nested'
+          },
+          'Next W': 'Next Week'
+        }
+      }
+    });
+
+    let message = i18n.getMessage('component.format');
+    assert.equal('min={min}, max1={max}, max2={max}, max3={max}', message);
+
+    message = i18n.getMessage('component.format', { min: 10, max: 100 });
+    assert.equal('min=10, max1=100, max2=100, max3=100', message);
+
+    message = i18n.getMessage('component.Next W');
+    assert.equal('Next Week', message);
+  });
+});

--- a/src/utils/I18nManager.spec.js
+++ b/src/utils/I18nManager.spec.js
@@ -233,20 +233,6 @@ describe('I18nManager', () => {
     assert.equal('Next Week', message);
   });
 
-  it('getMessage using fallback locale', () => {
-    const i18n = new I18nManager('de', [
-      {
-        locales: ['en'],
-        messages: {
-          a: 'fallback'
-        },
-      }
-    ]);
-    // there is no message in default/current locale 'de'
-    // fallback to default locale -> 'en' message
-    assert.strictEqual(i18n.getMessage('a'), 'fallback');
-  });
-
   it('dateFormat returns configured date format', () => {
     const i18n = new I18nManager('es', null,
       {


### PR DESCRIPTION
Messages defined in this way:
```javascript
{
  'a.b.c': 'hi'
}
```
or another way
```javascript
{
  a: {
    b: {
      c: 'hi'
    }
  }
}
```
are considered by i18n manager as equal and correspond to the same message key/path 'a.b.c'