### PR TITLE
Fixes numerical keys thrown `{0} nothing to repeat` exception.

### DIFF
--- a/src/utils/I18nManager.js
+++ b/src/utils/I18nManager.js
@@ -240,7 +240,7 @@ class I18nManager {
     // fill message parameter placeholders with passed values
     lodash.each(args, function(value, key) {
       if (!lodash.isNil(value)) {
-        message = message.replace(new RegExp(`{${key}}`, 'g'), value.toString());
+        message = message.replace(new RegExp(`\\{${key}\\}`, 'g'), value.toString());
       }
     });
 

--- a/src/utils/I18nManager.messages.spec.js
+++ b/src/utils/I18nManager.messages.spec.js
@@ -150,4 +150,17 @@ describe('I18nManager: messages', () => {
     message = i18n.getMessage('component.Next W');
     assert.equal('Next Week', message);
   });
+
+  it('should replace numerical params with payload array values', () => {
+    const i18n = new I18nManager();
+    i18n.register('randomCmp', {
+      en: {
+        'mymessage': 'My message with {0} and {1}.'
+      }
+    });
+
+    assert.equal('My message with first and last.', i18n.getMessage('mymessage', ['first', 'last']));
+    assert.equal('My message with first and {1}.', i18n.getMessage('mymessage', ['first']));
+    assert.equal('My message with {0} and {1}.', i18n.getMessage('mymessage'));
+  });
 });


### PR DESCRIPTION
Issue: #7 

Googled solution: [link](http://forum.getfuelcms.com/discussion/2486/console-error-uncaught-syntaxerror-invalid-regular-expression-0-nothing-to-repeat/p1)