### PR TITLE
Fixed support for am/pm AM/PM #21

### DIFF
--- a/src/external_modules/date-and-time.js
+++ b/src/external_modules/date-and-time.js
@@ -7,7 +7,6 @@
  * @preserve date-and-time.js (c) KNOWLEDGECODE | MIT
  */
 const date = {
-  A: ['a.m.', 'p.m.'],
   formatter: {
     YYYY: d => ('000' + d.getFullYear()).slice(-4),
     YY: d => ('0' + d.getFullYear()).slice(-2),
@@ -18,7 +17,8 @@ const date = {
     D: d => '' + d.getDate(),
     HH: d => ('0' + d.getHours()).slice(-2),
     H: d => '' + d.getHours(),
-    A: d => this.A[d.getHours() > 11 | 0],
+    A: d => ['AM', 'PM'][d.getHours() > 11 | 0],
+    a: d => ['am', 'pm'][d.getHours() > 11 | 0],
     hh: d => ('0' + (d.getHours() % 12 || 12)).slice(-2),
     h: d => '' + (d.getHours() % 12 || 12),
     mm: d => ('0' + d.getMinutes()).slice(-2),

--- a/src/utils/I18nManager.converters.spec.js
+++ b/src/utils/I18nManager.converters.spec.js
@@ -59,6 +59,36 @@ describe('I18nManager: converters', () => {
     assert.equal('10/01/2001 00:00:00', dateTimeAsString);
   });
 
+  it('should format and parse date and time with AM', () => {
+    const localeFormattingInfo = {
+      en: {
+        dateTimePattern: 'dd/MM/yyyy HH:mm:ss A'
+      }
+    };
+    const i18n = new I18nManager({
+      locale: 'en',
+      localeFormattingInfo
+    })
+    const date = new Date('December 17, 2005 09:24:00');
+    const dateTimeAsString = i18n.formatDateTime(date);
+    assert.equal('17/12/2005 09:24:00 AM', dateTimeAsString);
+  });
+
+  it('should format and parse date and time with pm', () => {
+    const localeFormattingInfo = {
+      en: {
+        dateTimePattern: "MM/dd/yyyy h:mm:ss a"
+      }
+    };
+    const i18n = new I18nManager({
+      locale: 'en',
+      localeFormattingInfo
+    })
+    const date = new Date('December 17, 2005 19:24:00');
+    const dateTimeAsString = i18n.formatDateTime(date);
+    assert.equal('12/17/2005 7:24:00 pm', dateTimeAsString);
+  });
+
   it('should format and parse numbers', () => {
     assert.equal('10,000', i18n.formatNumber(10000));
     assert.equal(10000, i18n.parseNumber('10,000'));


### PR DESCRIPTION
#21 

Changes: `i18n.formatDateTime` works exactly like before `1.2.2` (when it used moment.js). Formats and output: 

- format `MM/dd/yyyy h:mm:ss A` (uppercase `A`) -> `AM` or `PM`
- format `MM/dd/yyyy h:mm:ss a` (lowercase `a`) -> `am` or `pm`